### PR TITLE
Print TypeScript definitions

### DIFF
--- a/src/core/ht.c
+++ b/src/core/ht.c
@@ -1,0 +1,223 @@
+/**
+MIT License
+
+Copyright (c) 2021 Ben Hoyt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+// Simple hash table implemented in C.
+
+#include "ht.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+// Hash table entry (slot may be filled or empty).
+typedef struct {
+    const char* key;  // key is NULL if this slot is empty
+    void* value;
+} ht_entry;
+
+// Hash table structure: create with ht_create, free with ht_destroy.
+struct ht {
+    ht_entry* entries;  // hash slots
+    size_t capacity;    // size of _entries array
+    size_t length;      // number of items in hash table
+};
+
+#define INITIAL_CAPACITY 16  // must not be zero
+
+ht* ht_create(void) {
+    // Allocate space for hash table struct.
+    ht* table = malloc(sizeof(ht));
+    if (table == NULL) {
+        return NULL;
+    }
+    table->length = 0;
+    table->capacity = INITIAL_CAPACITY;
+
+    // Allocate (zero'd) space for entry buckets.
+    table->entries = calloc(table->capacity, sizeof(ht_entry));
+    if (table->entries == NULL) {
+        free(table); // error, free table before we return!
+        return NULL;
+    }
+    return table;
+}
+
+void ht_destroy(ht* table) {
+    // First free allocated keys.
+    for (size_t i = 0; i < table->capacity; i++) {
+        if (table->entries[i].key != NULL) {
+            free((void*)table->entries[i].key);
+        }
+    }
+
+    // Then free entries array and table itself.
+    free(table->entries);
+    free(table);
+}
+
+#define FNV_OFFSET 14695981039346656037UL
+#define FNV_PRIME 1099511628211UL
+
+// Return 64-bit FNV-1a hash for key (NUL-terminated). See description:
+// https://en.wikipedia.org/wiki/Fowler–Noll–Vo_hash_function
+static uint64_t hash_key(const char* key) {
+    uint64_t hash = FNV_OFFSET;
+    for (const char* p = key; *p; p++) {
+        hash ^= (uint64_t)(unsigned char)(*p);
+        hash *= FNV_PRIME;
+    }
+    return hash;
+}
+
+void* ht_get(ht* table, const char* key) {
+    // AND hash with capacity-1 to ensure it's within entries array.
+    uint64_t hash = hash_key(key);
+    size_t index = (size_t)(hash & (uint64_t)(table->capacity - 1));
+
+    // Loop till we find an empty entry.
+    while (table->entries[index].key != NULL) {
+        if (strcmp(key, table->entries[index].key) == 0) {
+            // Found key, return value.
+            return table->entries[index].value;
+        }
+        // Key wasn't in this slot, move to next (linear probing).
+        index++;
+        if (index >= table->capacity) {
+            // At end of entries array, wrap around.
+            index = 0;
+        }
+    }
+    return NULL;
+}
+
+// Internal function to set an entry (without expanding table).
+static const char* ht_set_entry(ht_entry* entries, size_t capacity,
+        const char* key, void* value, size_t* plength) {
+    // AND hash with capacity-1 to ensure it's within entries array.
+    uint64_t hash = hash_key(key);
+    size_t index = (size_t)(hash & (uint64_t)(capacity - 1));
+
+    // Loop till we find an empty entry.
+    while (entries[index].key != NULL) {
+        if (strcmp(key, entries[index].key) == 0) {
+            // Found key (it already exists), update value.
+            entries[index].value = value;
+            return entries[index].key;
+        }
+        // Key wasn't in this slot, move to next (linear probing).
+        index++;
+        if (index >= capacity) {
+            // At end of entries array, wrap around.
+            index = 0;
+        }
+    }
+
+    // Didn't find key, allocate+copy if needed, then insert it.
+    if (plength != NULL) {
+        key = strdup(key);
+        if (key == NULL) {
+            return NULL;
+        }
+        (*plength)++;
+    }
+    entries[index].key = (char*)key;
+    entries[index].value = value;
+    return key;
+}
+
+// Expand hash table to twice its current size. Return true on success,
+// false if out of memory.
+static bool ht_expand(ht* table) {
+    // Allocate new entries array.
+    size_t new_capacity = table->capacity * 2;
+    if (new_capacity < table->capacity) {
+        return false;  // overflow (capacity would be too big)
+    }
+    ht_entry* new_entries = calloc(new_capacity, sizeof(ht_entry));
+    if (new_entries == NULL) {
+        return false;
+    }
+
+    // Iterate entries, move all non-empty ones to new table's entries.
+    for (size_t i = 0; i < table->capacity; i++) {
+        ht_entry entry = table->entries[i];
+        if (entry.key != NULL) {
+            ht_set_entry(new_entries, new_capacity, entry.key,
+                         entry.value, NULL);
+        }
+    }
+
+    // Free old entries array and update this table's details.
+    free(table->entries);
+    table->entries = new_entries;
+    table->capacity = new_capacity;
+    return true;
+}
+
+const char* ht_set(ht* table, const char* key, void* value) {
+    assert(value != NULL);
+    if (value == NULL) {
+        return NULL;
+    }
+
+    // If length will exceed half of current capacity, expand it.
+    if (table->length >= table->capacity / 2) {
+        if (!ht_expand(table)) {
+            return NULL;
+        }
+    }
+
+    // Set entry and update length.
+    return ht_set_entry(table->entries, table->capacity, key, value,
+                        &table->length);
+}
+
+size_t ht_length(ht* table) {
+    return table->length;
+}
+
+hti ht_iterator(ht* table) {
+    hti it;
+    it._table = table;
+    it._index = 0;
+    return it;
+}
+
+bool ht_next(hti* it) {
+    // Loop till we've hit end of entries array.
+    ht* table = it->_table;
+    while (it->_index < table->capacity) {
+        size_t i = it->_index;
+        it->_index++;
+        if (table->entries[i].key != NULL) {
+            // Found next non-empty item, update iterator key and value.
+            ht_entry entry = table->entries[i];
+            it->key = entry.key;
+            it->value = entry.value;
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/core/ht.h
+++ b/src/core/ht.h
@@ -1,0 +1,73 @@
+/**
+MIT License
+
+Copyright (c) 2021 Ben Hoyt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+ 
+// Simple hash table implemented in C.
+
+#ifndef _HT_H
+#define _HT_H
+
+#include <stdbool.h>
+#include <stddef.h>
+
+// Hash table structure: create with ht_create, free with ht_destroy.
+typedef struct ht ht;
+
+// Create hash table and return pointer to it, or NULL if out of memory.
+ht* ht_create(void);
+
+// Free memory allocated for hash table, including allocated keys.
+void ht_destroy(ht* table);
+
+// Get item with given key (NUL-terminated) from hash table. Return
+// value (which was set with ht_set), or NULL if key not found.
+void* ht_get(ht* table, const char* key);
+
+// Set item with given key (NUL-terminated) to value (which must not
+// be NULL). If not already present in table, key is copied to newly
+// allocated memory (keys are freed automatically when ht_destroy is
+// called). Return address of copied key, or NULL if out of memory.
+const char* ht_set(ht* table, const char* key, void* value);
+
+// Return number of items in hash table.
+size_t ht_length(ht* table);
+
+// Hash table iterator: create with ht_iterator, iterate with ht_next.
+typedef struct {
+    const char* key;  // current key
+    void* value;      // current value
+
+    // Don't use these fields directly.
+    ht* _table;       // reference to hash table being iterated
+    size_t _index;    // current index into ht._entries
+} hti;
+
+// Return new hash table iterator (for use with ht_next).
+hti ht_iterator(ht* table);
+
+// Move iterator to next item in hash table, update iterator's key
+// and value to current item, and return true. If there are no more
+// items, return false. Don't call ht_set during iteration.
+bool ht_next(hti* it);
+
+#endif // _HT_H

--- a/src/core/js_builder.c
+++ b/src/core/js_builder.c
@@ -10,7 +10,6 @@ JSBuilder* js_builder_create() {
   jsb->indent_len = strlen(jsb->indent_str);
   jsb->sb = str_builder_create();
   jsb->ib = str_builder_create();
-  //str_builder_add_str(jsb->ib, jsb->indent_str, 0);
 
   return jsb;
 }

--- a/src/core/node.h
+++ b/src/core/node.h
@@ -2,7 +2,7 @@
 
 #include <stddef.h>
 #include <stdbool.h>
-#include "set.h"
+#include <stdlib.h>
 
 #define NODE_MACHINE_TYPE 0
 #define NODE_STATE_TYPE 1

--- a/src/core/string_list.c
+++ b/src/core/string_list.c
@@ -1,0 +1,60 @@
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include "string_list.h"
+
+void string_list_init(string_list_t* list) {
+  list->head = NULL;
+  list->tail = NULL;
+  list->length = 0;
+}
+
+void string_list_destroy(string_list_t* list) {
+  string_list_node_t* node = list->head;
+  while(node != NULL) {
+    string_list_node_t* next = node->next;
+    if(node->value != NULL) {
+      free(node->value);
+    }
+    free(node);
+    node = next; 
+  }
+}
+
+void string_list_append(string_list_t* list, char* value) {
+  string_list_node_t *node = malloc(sizeof(*node));
+  node->next = NULL;
+  node->value = strdup(value);
+
+  if(list->tail != NULL) {
+    list->tail->next = node;
+    list->tail = node;
+  } else {
+    list->head = node;
+    list->tail = node;
+  }
+  list->length++;
+}
+
+string_list_iterator_t string_list_iterator(string_list_t* list) {
+  string_list_iterator_t iterator;
+  iterator._list = list;
+  iterator.index = 0;
+  iterator.node = NULL;
+  return iterator;
+}
+
+bool string_list_next(string_list_iterator_t* iterator) {
+  if(iterator->node == NULL) {
+    iterator->node = iterator->_list->head;
+    return true;
+  } else {
+    string_list_node_t* node = iterator->node->next;
+    if(node == NULL) {
+      return false;
+    }
+    iterator->node = node;
+    iterator->index++;
+    return true;
+  }
+}

--- a/src/core/string_list.h
+++ b/src/core/string_list.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+
+typedef struct string_list_node_t {
+  char* value;
+  struct string_list_node_t* next;
+} string_list_node_t;
+
+typedef struct string_list_t {
+  string_list_node_t* head;
+  string_list_node_t* tail;
+  size_t length;
+} string_list_t;
+
+typedef struct string_list_iterator_t {
+  string_list_node_t* node;
+  size_t index;
+
+  string_list_t* _list;
+} string_list_iterator_t;
+
+void string_list_init(string_list_t*);
+void string_list_destroy(string_list_t*);
+void string_list_append(string_list_t*, char*);
+string_list_iterator_t string_list_iterator(string_list_t*);
+bool string_list_next(string_list_iterator_t*);
+
+static inline bool string_list_empty(string_list_t* list) {
+  return list->head == NULL;
+}

--- a/src/core/xstate/compiler.h
+++ b/src/core/xstate/compiler.h
@@ -1,13 +1,17 @@
 #pragma once
 
+#include <stdbool.h>
+
 typedef struct CompileResult {
   bool success;
   char* js;
+  char* dts;
   int flags;
 } CompileResult;
 
 CompileResult* xs_create();
-void xs_init(CompileResult*, int);
+void xs_init(CompileResult*, bool, bool);
 void compile_xstate(CompileResult*, char*, char*);
 char* xs_get_js(CompileResult*);
+char* xs_get_dts(CompileResult*);
 void destroy_xstate_result(CompileResult*);

--- a/src/core/xstate/core.h
+++ b/src/core/xstate/core.h
@@ -3,9 +3,12 @@
 #include "../js_builder.h"
 #include "../node.h"
 #include "../program.h"
+#include "../set.h"
+#include "ts_printer.h"
 
 // API flags
-#define FLAG_USE_REMOTE 1 << 0
+#define XS_FLAG_USE_REMOTE 1 << 0
+#define XS_FLAG_DTS 2 << 0
 
 // Machine implementation flags
 #define XS_HAS_STATE_PROP 1 << 0
@@ -17,6 +20,7 @@ typedef struct Ref {
 } Ref;
 
 typedef struct PrintState {
+  int flags;
   Program* program;
   Ref* guard;
   SimpleSet* guard_names;
@@ -27,6 +31,10 @@ typedef struct PrintState {
   Ref* service;
   SimpleSet* service_names;
   SimpleSet* events;
+  ts_printer_t* tsprinter;
+  char* cur_event_name;
+  char* cur_state_name;
+  bool in_entry;
 } PrintState;
 
 void xs_destroy_state_refs(PrintState*);

--- a/src/core/xstate/invoke.c
+++ b/src/core/xstate/invoke.c
@@ -26,6 +26,10 @@ void xs_compile_invoke(PrintState* state, JSBuilder* jsb, InvokeNode* invoke_nod
       SymbolExpression* symbol_expression = (SymbolExpression*)invoke_expression->ref;
       js_builder_add_string(jsb, symbol_expression->name);
       xs_add_service_ref(state, symbol_expression->name, (Expression*)invoke_expression);
+
+      if(state->flags & XS_FLAG_DTS) {
+        ts_printer_add_invoke(state->tsprinter, symbol_expression->name);
+      }
       break;
     }
   }

--- a/src/core/xstate/machine.h
+++ b/src/core/xstate/machine.h
@@ -3,6 +3,7 @@
 #include "../js_builder.h"
 #include "../node.h"
 #include "core.h"
+#include "ts_printer.h"
 
 void xs_add_machine_binding_name(JSBuilder*, MachineNode*);
 void xs_enter_machine(PrintState*, JSBuilder*, Node*);

--- a/src/core/xstate/ts_printer.c
+++ b/src/core/xstate/ts_printer.c
@@ -1,0 +1,470 @@
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../str_builder.h"
+#include "../set.h"
+#include "ts_printer.h"
+
+static void add_str_union(str_builder_t* sb, char* value) {
+  int len = str_builder_len(sb);
+  char c = str_builder_char_at(sb, len - 1);
+  if(c == '\'') {
+    str_builder_add_str(sb, " | ", 3);
+  }
+
+  str_builder_add_char(sb, '\'');
+  str_builder_add_str(sb, value, 0);
+  str_builder_add_char(sb, '\'');
+}
+
+static xs_executor_t* executor_alloc() {
+  xs_executor_t* executor = malloc(sizeof(*executor));
+  executor->events = malloc(sizeof(*executor->events));
+  executor->events_s = malloc(sizeof(*executor->events_s));
+  return executor;
+}
+
+static void executor_init(xs_executor_t* executor) {
+  string_list_init(executor->events);
+  set_init(executor->events_s);
+}
+
+static void executor_destroy(xs_executor_t* executor) {
+  string_list_destroy(executor->events);
+  free(executor->events);
+  set_destroy(executor->events_s);
+  free(executor);
+}
+
+static void executor_add(xs_executor_t* executor, char* event_name) {
+  if(set_contains(executor->events_s, event_name) == SET_FALSE) {
+    set_add(executor->events_s, event_name);
+    string_list_append(executor->events, event_name);
+  }
+}
+
+void ts_printer_init(ts_printer_t* printer) {
+  printer->flags = 0;
+  printer->buffer = js_builder_create();
+  printer->machine_name = NULL;
+  printer->xstate_specifier = NULL;
+  printer->event_names_sb = NULL;
+  printer->data_names_sb = NULL;
+  printer->machine_def_sb = str_builder_create();
+  printer->guards = NULL;
+  printer->actions = NULL;
+  printer->invokes = NULL;
+  printer->actors = NULL;
+  printer->delays = NULL;
+  printer->state_entries = NULL;
+  printer->entry_actions = NULL;
+}
+
+void ts_printer_destroy(ts_printer_t* printer) {
+  js_builder_destroy(printer->buffer);
+  if(printer->event_names_sb != NULL) {
+    str_builder_destroy(printer->event_names_sb);
+  }
+  if(printer->data_names_sb != NULL) {
+    str_builder_destroy(printer->data_names_sb);
+  }
+  if(printer->actions != NULL) {
+    hti it = ht_iterator(printer->actions);
+    while (ht_next(&it)) {
+      xs_executor_t* executor = (xs_executor_t*)it.value;
+      executor_destroy(executor);
+    }
+  }
+  if(printer->guards != NULL) {
+    hti it = ht_iterator(printer->guards);
+    while (ht_next(&it)) {
+      xs_executor_t* executor = (xs_executor_t*)it.value;
+      executor_destroy(executor);
+    }
+  }
+  if(printer->invokes != NULL) {
+    string_list_destroy(printer->invokes);
+    free(printer->invokes);
+  }
+  if(printer->actors != NULL) {
+    string_list_destroy(printer->actors);
+    free(printer->actors);
+  }
+  if(printer->delays != NULL) {
+    string_list_destroy(printer->delays);
+    free(printer->delays);
+  }
+  if(printer->state_entries != NULL) {
+    ht_destroy(printer->state_entries);
+  }
+  if(printer->entry_actions != NULL) {
+    ht_destroy(printer->entry_actions);
+  }
+
+  free(printer);
+}
+
+ts_printer_t* ts_printer_alloc() {
+  ts_printer_t* printer = malloc(sizeof(*printer));
+
+  return printer;
+}
+
+static void build_import_clause(ts_printer_t* printer, str_builder_t* buffer) {
+  string_list_t identifiers;
+  string_list_init(&identifiers);
+
+  if(printer->flags & XS_TS_PROGRAM_USES_ACTION) {
+    string_list_append(&identifiers, "Action");
+  }
+  if(printer->flags & XS_TS_PROGRAM_USES_DELAY) {
+    string_list_append(&identifiers, "DelayConfig");
+  }
+  if(printer->flags & XS_TS_PROGRAM_USES_GUARD) {
+    string_list_append(&identifiers, "ConditionPredicate");
+  }
+  if(printer->flags & XS_TS_PROGRAM_USES_INVOKE) {
+    string_list_append(&identifiers, "InvokeCreator");
+  }
+  string_list_append(&identifiers, "StateMachine");
+
+  str_builder_add_str(buffer, "import { ", 0);
+
+  int i = 0;
+  string_list_iterator_t it = string_list_iterator(&identifiers);
+  while(string_list_next(&it)) {
+    if(i > 0) {
+      str_builder_add_str(buffer, ", ", 0);
+    }
+    str_builder_add_str(buffer, it.node->value, 0);
+    i++;
+  }
+
+  str_builder_add_str(buffer, " } from '", 0);
+  str_builder_add_str(buffer, printer->xstate_specifier, 0);
+  str_builder_add_str(buffer, "';\n", 0);
+}
+
+static char* build_extract_clause(string_list_t* event_list) {
+  str_builder_t* sb = str_builder_create();
+  str_builder_add_str(sb, "Extract<TEvent, { type: ", 0);
+  string_list_iterator_t ir = string_list_iterator(event_list);
+  while(string_list_next(&ir)) {
+    if(ir.index > 0) {
+      str_builder_add_str(sb, " | ", 0);
+    }
+
+    str_builder_add_char(sb, '\'');
+    str_builder_add_str(sb, ir.node->value, 0);
+    str_builder_add_char(sb, '\'');
+  }
+  str_builder_add_str(sb, " }>", 0);
+  char* extract_clause = str_builder_dump(sb, NULL);
+  str_builder_destroy(sb);
+  return extract_clause;
+}
+
+static void print_machine_definitions(ts_printer_t* printer) {
+  JSBuilder* buffer = printer->buffer;
+
+  if(printer->event_names_sb != NULL) {
+    js_builder_add_char(buffer, '\n');
+    js_builder_add_str(buffer, str_builder_dump(printer->event_names_sb, NULL));
+    js_builder_add_str(buffer, ";\n");
+  }
+
+  if(printer->data_names_sb != NULL) {
+    js_builder_add_char(buffer, '\n');
+    js_builder_add_str(buffer, str_builder_dump(printer->data_names_sb, NULL));
+    js_builder_add_str(buffer, ";\n");
+  }
+
+  // interface CreateMachineOptions<TContext, TEvent extends EventObject> {
+  js_builder_add_str(buffer, "\nexport interface Create");
+  js_builder_add_str(buffer, printer->machine_name);
+  js_builder_add_str(buffer, "Options<TContext, TEvent extends { type: ");
+  js_builder_add_str(buffer, printer->machine_name);
+  js_builder_add_str(buffer, "EventNames }> ");
+  js_builder_start_object(buffer);
+if(printer->actions != NULL) {
+    js_builder_start_prop(buffer, "actions");
+    js_builder_start_object(buffer);
+    hti it = ht_iterator(printer->actions);
+    while (ht_next(&it)) {      
+      js_builder_start_prop(buffer, (char*)it.key);
+      js_builder_add_str(buffer, "Action<\n");
+      js_builder_increase_indent(buffer);
+      js_builder_add_indent(buffer);
+      js_builder_add_str(buffer, "TContext,\n");
+      js_builder_add_indent(buffer);
+      xs_executor_t* executor = (xs_executor_t*)it.value;
+      if(executor->events->length > 0) {
+        char* extract_clause = build_extract_clause(executor->events);
+        js_builder_add_str(buffer, "TEvent extends ");
+        js_builder_add_str(buffer, extract_clause);
+        js_builder_add_str(buffer, " ? ");
+        js_builder_add_str(buffer, extract_clause);
+        js_builder_add_str(buffer, " : TEvent\n");
+      } else {
+        js_builder_add_str(buffer, "TEvent\n");
+      }
+      js_builder_decrease_indent(buffer);
+      js_builder_add_indent(buffer);
+      js_builder_add_str(buffer, ">");
+    }
+    js_builder_end_object(buffer);
+  }
+  if(printer->delays != NULL) {
+    js_builder_start_prop(buffer, "delays");
+    js_builder_start_object(buffer);
+    string_list_iterator_t it = string_list_iterator(printer->delays);
+    while(string_list_next(&it)) {
+      js_builder_start_prop(buffer, it.node->value);
+      js_builder_add_str(buffer, "DelayConfig<TContext, TEvent>");
+    }
+    js_builder_end_object(buffer);
+  }
+  if(printer->guards != NULL) {
+    js_builder_start_prop(buffer, "guards");
+    js_builder_start_object(buffer);
+    hti it = ht_iterator(printer->guards);
+    while (ht_next(&it)) {
+      /**
+       * Guard<
+       *   TContext,
+       *   TEvent extends Extract<TEvent, { type: 'GO_BACK' }> ? Extract<TEvent, { type: 'GO_BACK' }> : TEvent
+       * >;
+       **/
+      // Extract<TEvent, { type: 'next' | 'go_back' }>
+      
+      js_builder_start_prop(buffer, (char*)it.key);
+      js_builder_add_str(buffer, "ConditionPredicate<\n");
+      js_builder_increase_indent(buffer);
+      js_builder_add_indent(buffer);
+      js_builder_add_str(buffer, "TContext,\n");
+      js_builder_add_indent(buffer);
+      xs_executor_t* executor = (xs_executor_t*)it.value;
+      if(executor->events->length > 0) {
+        char* extract_clause = build_extract_clause(executor->events);
+        js_builder_add_str(buffer, "TEvent extends ");
+        js_builder_add_str(buffer, extract_clause);
+        js_builder_add_str(buffer, " ? ");
+        js_builder_add_str(buffer, extract_clause);
+        js_builder_add_str(buffer, " : TEvent\n");
+      } else {
+        js_builder_add_str(buffer, "TEvent\n");
+      }
+      js_builder_decrease_indent(buffer);
+      js_builder_add_indent(buffer);
+      js_builder_add_str(buffer, ">");
+    }
+    js_builder_end_object(buffer);
+  }
+  if(printer->invokes != NULL || printer->actors != NULL) {
+    js_builder_start_prop(buffer, "services");
+    js_builder_start_object(buffer);
+    if(printer->invokes != NULL) {
+      string_list_iterator_t ir = string_list_iterator(printer->invokes);
+      while(string_list_next(&ir)) {
+        char* invoke_name = ir.node->value;
+        js_builder_start_prop(buffer, invoke_name);
+        js_builder_add_str(buffer, "InvokeCreator<TContext, TEvent>");
+      }
+    }
+    if(printer->actors != NULL) {
+      string_list_iterator_t ir = string_list_iterator(printer->actors);
+      while(string_list_next(&ir)) {
+        char* actor_name = ir.node->value;
+        js_builder_start_prop(buffer, actor_name);
+        js_builder_add_str(buffer, "StateMachine<TContext, any, TEvent>");
+      }
+    }
+    js_builder_end_object(buffer);
+  }
+  js_builder_end_object(buffer);
+
+  // Create machine definition
+  js_builder_add_str(buffer, "\n\n");
+  js_builder_add_str(buffer, str_builder_dump(printer->machine_def_sb, NULL));
+}
+
+char* ts_printer_dump(ts_printer_t* printer) {
+  str_builder_t* buffer = str_builder_create();
+  build_import_clause(printer, buffer);
+  print_machine_definitions(printer);
+  str_builder_add_str(buffer, js_builder_dump(printer->buffer), 0);
+  
+  char* result = str_builder_dump(buffer, NULL);
+  str_builder_destroy(buffer);
+  return result;
+}
+
+void ts_printer_add_event(ts_printer_t* printer, char* event_name) {
+  if(printer->event_names_sb == NULL) {
+    printer->event_names_sb = str_builder_create();
+    str_builder_add_str(printer->event_names_sb, "type ", 0);
+    str_builder_add_str(printer->event_names_sb, printer->machine_name, 0);
+    str_builder_add_str(printer->event_names_sb, "EventNames = ", 0);
+  }
+
+  add_str_union(printer->event_names_sb, event_name);
+}
+
+void ts_printer_add_data(ts_printer_t* printer, char* name) {
+  if(printer->data_names_sb == NULL) {
+    printer->data_names_sb = str_builder_create();
+    str_builder_add_str(printer->data_names_sb, "type ", 0);
+    str_builder_add_str(printer->data_names_sb, printer->machine_name, 0);
+    str_builder_add_str(printer->data_names_sb, "KnownContextKeys = ", 0);
+  }
+
+  add_str_union(printer->data_names_sb, name);
+}
+
+void ts_printer_add_guard(ts_printer_t* printer, char* guard_name, char* event_name) {
+  if(printer->guards == NULL) {
+    printer->guards = ht_create();
+  }
+  xs_executor_t* guard = (xs_executor_t*)ht_get(printer->guards, guard_name);
+  if(guard == NULL) {
+    guard = executor_alloc();
+    executor_init(guard);
+    ht_set(printer->guards, guard_name, guard);
+  }
+  executor_add(guard, event_name);
+  printer->flags |= XS_TS_PROGRAM_USES_GUARD;
+}
+
+void ts_printer_add_action(ts_printer_t* printer, char* action_name, char* event_name) {
+  if(printer->actions == NULL) {
+    printer->actions = ht_create();
+  }
+  xs_executor_t* action = (xs_executor_t*)ht_get(printer->actions, action_name);
+  if(action == NULL) {
+    action = executor_alloc();
+    executor_init(action);
+    ht_set(printer->actions, action_name, action);
+  }
+  executor_add(action, event_name);
+  printer->flags |= XS_TS_PROGRAM_USES_ACTION;
+}
+
+void ts_printer_add_invoke(ts_printer_t* printer, char* invoke_name) {
+  //char* cloned_invoke_name = strdup(invoke_name);
+  if(printer->invokes == NULL) {
+    printer->invokes = malloc(sizeof(*printer->invokes));
+    string_list_init(printer->invokes);
+  }
+  string_list_append(printer->invokes, invoke_name);
+  printer->flags |= XS_TS_PROGRAM_USES_INVOKE;
+}
+
+void ts_printer_add_actor(ts_printer_t* printer, char* name) {
+  if(printer->actors == NULL) {
+    printer->actors = malloc(sizeof(*printer->actors));
+    string_list_init(printer->actors);
+  }
+  string_list_append(printer->actors, name);
+}
+
+void ts_printer_add_delay(ts_printer_t* printer, char* name) {
+  if(printer->delays == NULL) {
+    printer->delays = malloc(sizeof(*printer->delays));
+    string_list_init(printer->delays);
+  }
+  string_list_append(printer->delays, name);
+  printer->flags |= XS_TS_PROGRAM_USES_DELAY;
+}
+
+// function createMachine<TContext extends LucyKnownContext<KnownContextKeys>, TEvent extends { type: EventNames } = any>()
+void ts_printer_create_machine(ts_printer_t* printer) {
+  str_builder_t* sb = printer->machine_def_sb;
+  if(printer->machine_flags & XS_TS_MACHINE_DEFAULT) {
+    str_builder_add_str(sb, "export default ", 0);
+  }
+
+  str_builder_add_str(sb, "function create", 0);
+  str_builder_add_str(sb, printer->machine_name, 0);
+  str_builder_add_str(sb, "<TContext extends Record<", 0);
+  str_builder_add_str(sb, printer->machine_name, 0);
+  str_builder_add_str(sb, "KnownContextKeys, any>, TEvent extends { type: ", 0);
+  str_builder_add_str(sb, printer->machine_name, 0);
+  str_builder_add_str(sb, "EventNames } = any>(options: ", 0);
+  str_builder_add_str(sb, "Create", 0);
+  str_builder_add_str(sb, printer->machine_name, 0);
+  str_builder_add_str(sb, "Options<TContext, TEvent>): StateMachine<TContext, any, TEvent>;", 0);
+}
+
+void ts_printer_add_machine_name(ts_printer_t* printer, char* machine_name) {
+  if(machine_name == NULL) {
+    printer->machine_flags |= XS_TS_MACHINE_DEFAULT;
+    printer->machine_name = "Machine";
+  } else {
+    str_builder_t* sb = str_builder_create();
+    int machine_name_len = strlen(machine_name);
+    str_builder_add_char(sb, toupper(machine_name[0]));
+    int i = 1;
+    while(i < machine_name_len) {
+      str_builder_add_char(sb, machine_name[i]);
+      i++;
+    }
+    printer->machine_name = str_builder_dump(sb, NULL);
+    str_builder_destroy(sb);
+  }
+}
+
+void ts_printer_add_state_entry(ts_printer_t* printer, char* event_name, char* state_name) {
+  if(printer->state_entries == NULL) {
+    printer->state_entries = ht_create();
+  }
+  string_list_t* event_list = (string_list_t*)ht_get(printer->state_entries, state_name);
+  if(event_list == NULL) {
+    event_list = malloc(sizeof(*event_list));
+    string_list_init(event_list);
+    ht_set(printer->state_entries, state_name, event_list);
+  }
+
+  string_list_append(event_list, event_name);
+}
+
+void ts_printer_add_entry_action(ts_printer_t* printer, char* state_name, char* action_name) {
+  // Map<state_name, List<ActionName>>
+  if(printer->entry_actions == NULL) {
+    printer->entry_actions = ht_create();
+  }
+
+  string_list_t* actions = (string_list_t*)ht_get(printer->entry_actions, state_name);
+  if(actions == NULL) {
+    actions = malloc(sizeof(*actions));
+    string_list_init(actions);
+    ht_set(printer->entry_actions, state_name, actions);
+  }
+
+  string_list_append(actions, action_name);
+}
+
+void ts_printer_figure_out_entry_events(ts_printer_t* printer) {
+  //ht* state_entries; // Map<state_name, List<EventName>>
+  //ht* entry_actions; // Map<state_name, List<ActionName>>
+
+  if(printer->state_entries != NULL && printer->entry_actions != NULL) {
+    hti it = ht_iterator(printer->state_entries);
+    while (ht_next(&it)) {
+      const char* state_name = it.key;
+      string_list_t* event_list = (string_list_t*)it.value;
+
+      string_list_t* state_entry_actions = ht_get(printer->entry_actions, state_name);
+      if(state_entry_actions != NULL) {
+        string_list_iterator_t itea = string_list_iterator(state_entry_actions);
+        while(string_list_next(&itea)) {
+          string_list_iterator_t iti = string_list_iterator(event_list);
+          char* action_name = itea.node->value;
+          while(string_list_next(&iti)) {
+            char* event_name = iti.node->value;
+            ts_printer_add_action(printer, action_name, event_name);
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/core/xstate/ts_printer.h
+++ b/src/core/xstate/ts_printer.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "../ht.h"
+#include "../js_builder.h"
+#include "../string_list.h"
+#include "../set.h"
+
+#define XS_TS_PROGRAM_USES_GUARD 1 << 0
+#define XS_TS_PROGRAM_USES_ACTION 2 << 0
+#define XS_TS_PROGRAM_USES_INVOKE 3 << 0
+#define XS_TS_PROGRAM_USES_DELAY 4 << 0
+
+#define XS_TS_MACHINE_DEFAULT 1 << 0
+
+typedef struct xs_executor_t {
+  string_list_t* events;
+  SimpleSet* events_s;
+} xs_executor_t;
+
+typedef struct ts_printer_t {
+  int flags;
+
+  int machine_flags;
+  char* machine_name;
+  char* xstate_specifier;
+  JSBuilder* buffer;
+  str_builder_t* imp_sb;
+  str_builder_t* event_names_sb;
+  str_builder_t* data_names_sb;
+  str_builder_t* machine_def_sb;
+
+  ht* guards;
+  ht* actions;
+  string_list_t* invokes;
+  string_list_t* actors;
+  string_list_t* delays;
+
+  ht* state_entries; // Map<state, List<Events>>
+  ht* entry_actions; // Map<state, List<Actions>>
+} ts_printer_t;
+
+void ts_printer_init(ts_printer_t*);
+void ts_printer_destroy(ts_printer_t*);
+char* ts_printer_dump(ts_printer_t*);
+ts_printer_t* ts_printer_alloc();
+
+void ts_printer_add_event(ts_printer_t*, char*);
+void ts_printer_add_data(ts_printer_t*, char*);
+void ts_printer_add_guard(ts_printer_t*, char*, char*);
+void ts_printer_add_action(ts_printer_t*, char*, char*);
+void ts_printer_add_invoke(ts_printer_t*, char*);
+void ts_printer_add_actor(ts_printer_t*, char*);
+void ts_printer_add_delay(ts_printer_t*, char*);
+void ts_printer_create_machine(ts_printer_t*);
+void ts_printer_add_machine_name(ts_printer_t*, char*);
+void ts_printer_add_state_entry(ts_printer_t*, char*, char*);
+void ts_printer_add_entry_action(ts_printer_t*, char*, char*);
+void ts_printer_figure_out_entry_events(ts_printer_t*);

--- a/test/snapshots/symbols/expected.js
+++ b/test/snapshots/symbols/expected.js
@@ -10,7 +10,7 @@ export default function({ actions, assigns, context = {}, delays, guards, servic
           next: {
             target: 'loading',
             cond: ['isValid', 'check'],
-            actions: ['log']
+            actions: ['log', 'namer']
           }
         }
       },
@@ -22,6 +22,7 @@ export default function({ actions, assigns, context = {}, delays, guards, servic
         }
       },
       loaded: {
+        exit: ['log'],
         after: {
           wait: {
             target: 'homescreen',
@@ -43,6 +44,9 @@ export default function({ actions, assigns, context = {}, delays, guards, servic
     actions: {
       logger: actions.doLog,
       log: actions.log,
+      namer: assign({
+        name: assigns.namer
+      }),
       updateUI: actions.updateUI,
       incrementLoads: assign({
         count: assigns.incrementLoads

--- a/test/snapshots/symbols/input.lucy
+++ b/test/snapshots/symbols/input.lucy
@@ -2,7 +2,7 @@ action logger = :doLog
 guard isValid = :checkValid
 
 initial state idle {
-  next => isValid => guard(:check) => action(:log) => loading
+  next => isValid => guard(:check) => action(:log) => assign(name, :namer) => loading
 }
 
 state loading {
@@ -15,6 +15,8 @@ state loading {
 
 state loaded {
   delay(:wait) => logger => homescreen
+
+  @exit => action(:log)
 }
 
 state homescreen {

--- a/test/unit/remote_imports/test.sh
+++ b/test/unit/remote_imports/test.sh
@@ -7,7 +7,7 @@ input="$dir/input.lucy"
 expected="$dir/expected.js"
 
 # Before
-tmp=$(mktemp)
+tmp="$(mktemp -d)/out.js"
 
 # Run compiler
 $LUCYC --remote-imports --out-file $tmp $input


### PR DESCRIPTION
This adds support for producing TypeScript definitions through `.d.ts`
file. The plan is to release this with a `--experimental-dts` flag,
  initially only available from the CLI, then as it becomes stable to
  remove that flag and replace it with a `--no-dts` flag as an opt-out.

Closes #15